### PR TITLE
Fixing issue where shutdown completes when a comparison is still in flight

### DIFF
--- a/forastero/bench.py
+++ b/forastero/bench.py
@@ -340,7 +340,6 @@ class BaseBench:
                     assert tb.scoreboard.result, "Scoreboard reported test failure"
 
                 return cocotb.decorators._RunningTest(_run_test(), self)
-            
 
         def _do_decorate(func):
             # _testcase acts as a function which returns a decorator, hence the

--- a/forastero/scoreboard.py
+++ b/forastero/scoreboard.py
@@ -107,7 +107,7 @@ class Channel:
                 mismatch(self, mon, ref)
             elif match is not None:
                 match(self, mon, ref)
-            # Release the lock once the comparison is complete
+            # Release the lock after the comparison completes
             self._lock.release()
 
     async def drain(self) -> None:


### PR DESCRIPTION
The scoreboard channel draining did not check if there was a transaction in flight (i.e. a monitor transaction had been captured but the matching reference transaction wasn't yet provided) and would incorrectly shutdown cleanly 