### PR TITLE
Adding support for funnel scoreboard channels

### DIFF
--- a/forastero/bench.py
+++ b/forastero/bench.py
@@ -144,7 +144,8 @@ class BaseBench:
         name: str,
         comp_or_coro: Component | Coroutine = None,
         scoreboard: bool = True,
-        scoreboard_verbose: bool = False
+        scoreboard_verbose: bool = False,
+        scoreboard_queues: list[str] | None = None,
     ) -> None:
         """
         Register a driver, monitor, or coroutine with the testbench. Drivers and
@@ -153,16 +154,16 @@ class BaseBench:
         the scoreboard unless explicitly requested. Coroutines must also be named
         and are required to complete before the test will shutdown.
 
-        :param name: \
-            Name of the component or coroutine
-        :param comp_or_coro: \
-            Component instance or coroutine
-        :param scoreboard: \
-            Only applies to monitors, controls whether it is registered with \
-            the scoreboard
-        :param scoreboard_verbose: \
-            Only applies to scoreboarded monitors, controls whether to log \
-            each transaction, even when they don't mismatch
+        :param name:         Name of the component or coroutine
+        :param comp_or_coro: Component instance or coroutine
+        :param scoreboard:   Only applies to monitors, controls whether it is
+                             registered with the scoreboard
+        :param scoreboard_verbose: Only applies to scoreboarded monitors,
+                                   controls whether to log each transaction, even
+                                   when they don't mismatch
+        :param scoreboard_queues:  When a list of queues is provided, the
+                                   scoreboard infers use of a funnel-type
+                                   channel
         """
         assert isinstance(name, str), f"Name must be a string '{name}'"
         if asyncio.iscoroutine(comp_or_coro):
@@ -176,7 +177,9 @@ class BaseBench:
             setattr(self, name, comp_or_coro)
             comp_or_coro.seed(self.random)
             if scoreboard and isinstance(comp_or_coro, BaseMonitor):
-                self.scoreboard.attach(comp_or_coro, verbose=scoreboard_verbose)
+                self.scoreboard.attach(comp_or_coro,
+                                       verbose=scoreboard_verbose,
+                                       queues=scoreboard_queues)
         else:
             raise TypeError(f"Unsupported object: {comp_or_coro}")
 

--- a/forastero/component.py
+++ b/forastero/component.py
@@ -19,6 +19,7 @@ from enum import Enum
 from random import Random
 from typing import Any, ClassVar
 
+import cocotb
 from cocotb.handle import ModifiableObject
 from cocotb.log import _COCOTB_LOG_LEVEL_DEFAULT, SimLog
 from cocotb.triggers import Event, RisingEdge
@@ -106,7 +107,9 @@ class Component:
         """
         # Call direct handlers
         for handler in self._handlers[event]:
-            handler(self, event, obj)
+            call = handler(self, event, obj)
+            if asyncio.iscoroutine(call):
+                cocotb.start_soon(call)
         # Trigger pending events
         events = self._waiting[event][:]
         self._waiting[event].clear()


### PR DESCRIPTION
Adds support for funnel scoreboard channels, useful where the hardware interleaves different streams and which stream will get the bus is unknown if treating the hardware as a black box. A funnel channel has multiple queues, and the head of all queues are considered to determine which, if any, channel has a matching transaction.