### PR TITLE
Hierarchical logging

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,17 +93,20 @@ as a test, Forastero replaces this with a decorator defined by the testbench
 class. For example:
 
 ```python
+from cocotb.log import SimLog
+
 from ..testbench import Testbench
 
 @Testbench.testcase()
-async def smoke(tb : Testbench):
+async def smoke(tb : Testbench, log: SimLog):
     ...
 ```
 
 As shown above, `@cocotb.test()` is replaced by `@Testbench.testcase()` - this
 performs all the same functions but replaces the `dut` argument that cocotb
-normally provides with a pointer to an instance of `Testbench` instead. This
-decorator does provide some new arguments:
+normally provides with a pointer to an instance of `Testbench` instead and
+provides a second argument called `log`. This decorator does provide some new
+arguments:
 
  * `reset` - defaults to `True`, but if set to `False` it will skip the standard
    reset and initialisation preamble of the testbench and immediately start the

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,52 @@
+Forastero builds on cocotb's
+[SimLog](https://docs.cocotb.org/en/stable/_modules/cocotb/log.html) infrastructure,
+adding hierarchical control over logging verbosity of each driver, monitor,
+scoreboard, testcase, and other testbench component. The `SimLog` infrastructure
+is in itself an extension of Python's built-in
+[logging](https://docs.python.org/3/library/logging.html) library.
+
+Forastero provides the following levels of hierarchy:
+
+ * `tb` - the root of the logging hierarchy;
+ * `tb.orchestration` - used for log messages to do with testbench sequencing
+   (e.g. used when draining different drivers and monitors at the end of a test);
+ * `tb.scoreboard` - used for messages emitted from the scoreboard;
+ * `tb.scoreboard.channels.<X>` - used for messages emitted from a particular
+   scoreboard channel;
+ * `tb.driver.<X>` - used for messages emitted from a particular driver (when
+   extending from [BaseDriver](./classes/driver.md));
+ * `tb.monitor.<X>` - used for messages emitted from a particular monitor (when
+   extending from [BaseMonitor](./classes/monitor.md));
+ * `tb.io.<X>` - used for messages emitted from a particular I/O wrapper class
+   (when extending from [BaseIO](./classes/io.md));
+ * `tb.testcase.<X>` - used for messages emitted from a particular testcase.
+
+These logging contexts are created using the `fork_log` method of
+[BaseBench](./classes/bench.md). If you want to introduce custom layers of
+hierarchy, then you should similarly call `fork_log` with your logging context
+e.g.:
+
+```python
+@Testbench.testcase()
+async def my_testcase(tb, log):
+    my_sub_log = tb.fork_log("testcase", "my_testcase", "my_sub_log")
+    my_sub_log.info("Hello!")
+```
+
+Logging verbosity is controlled hierarchically, for example the root log (`tb`)
+can be set to `INFO` verbosity while a specific driver (e.g. `tb.driver.mydriver`)
+can be set to `DEBUG` verbosity. This allows selective high-verbosity messages
+to be shown in the log, while suppressing them from areas of no interest.
+
+Hierarchical log verbosity is controlled via the test parameters file:
+
+```json
+{
+    "verbosity": {
+        "tb": "info",
+        "tb.driver.mydriver": "debug",
+        "tb.testcase.mytestcase": "warning"
+    }
+}
+```
+

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -50,3 +50,8 @@ Hierarchical log verbosity is controlled via the test parameters file:
 }
 ```
 
+The verbosity control should always provide at least a `tb` root context, and
+can then provide any number of refinements for specific log contexts. For each
+context the value should map to one of the
+[Python logging level names](https://docs.python.org/3/library/logging.html#logging-levels),
+where the value is case-insensitive.

--- a/forastero/component.py
+++ b/forastero/component.py
@@ -21,7 +21,6 @@ from typing import Any, ClassVar
 
 import cocotb
 from cocotb.handle import ModifiableObject
-from cocotb.log import _COCOTB_LOG_LEVEL_DEFAULT, SimLog
 from cocotb.triggers import Event, RisingEdge
 
 from .io import BaseIO
@@ -66,8 +65,7 @@ class Component:
         self.random = Random(random.random() if random else 0)
         self.name = name or type(self).__name__
         self.blocking = blocking
-        self.log = SimLog(name=self.name)
-        self.log.setLevel(_COCOTB_LOG_LEVEL_DEFAULT)
+        self.log = self.tb.fork_log(type(self).__name__.lower(), self.name)
         self._lock = asyncio.Lock()
         self._handlers = defaultdict(list)
         self._ready = Event()

--- a/forastero/io.py
+++ b/forastero/io.py
@@ -15,6 +15,7 @@
 from enum import IntEnum
 from typing import Any
 
+from cocotb.log import SimLog
 from cocotb.handle import HierarchyObject
 
 
@@ -70,7 +71,7 @@ class BaseIO:
                 sig += f"_{self.__name}"
             sig += f"_{comp}"
             if not hasattr(self.__dut, sig):
-                dut._log.info(
+                SimLog("tb").getChild(f"io.{type(self).__name__.lower()}").info(
                     f"{type(self).__name__}: Did not find I/O component {sig} on {dut}"
                 )
                 continue
@@ -83,7 +84,7 @@ class BaseIO:
                 sig += f"_{self.__name}"
             sig += f"_{comp}"
             if not hasattr(self.__dut, sig):
-                dut._log.info(
+                SimLog("tb").getChild(f"io.{type(self).__name__.lower()}").info(
                     f"{type(self).__name__}: Did not find I/O component {sig} on {dut}"
                 )
                 continue

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ markdown_extensions:
 nav:
   - Welcome: "index.md"
   - Components: "components.md"
+  - Logging: "logging.md"
   - API Reference:
     - IO: "classes/io.md"
     - Transactions: "classes/transaction.md"


### PR DESCRIPTION
This PR adds support for hierarchical logging contexts:

 * The root context is now called `tb`
 * There are distinct contexts for test orchestration (`tb.orchestration`), scoreboard (`tb.scoreboard.*`), drivers (`tb.driver.*`), monitors (`tb.monitor.*`), test cases (`tb.testcase.*`) and I/O (`tb.io.*`);
 * Hierarchical verbosity levels can be controlled via the test parameters JSON file.

**NOTE** This is a breaking change because test cases will now be provided with a new second argument of `log`, which is a context-specific logging instance - e.g.:

```python
@Testbench.testcase()
async def my_testcase(tb, log):
    log.info("HELLO!")
```