### PR TITLE
Sequence arbitration

### DIFF
--- a/docs/classes/sequences.md
+++ b/docs/classes/sequences.md
@@ -10,6 +10,12 @@
       heading_level: 2
       show_source: false
 
+::: forastero.sequence.SeqArbiter
+    options:
+      show_root_heading: true
+      heading_level: 2
+      show_source: false
+
 ::: forastero.sequence.SeqContextEvent
     options:
       show_root_heading: true

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -298,3 +298,14 @@ Each sequence scheduled is provided with a unique instance of
 
 A sequence should always use the context for logging and random number generation
 rather than accessing the root testbench directly.
+
+## Sequence Arbitration
+
+When more than one sequence is scheduled, the arbiter is responsible for deciding
+which sequence is able to claim locks first - this is especially important when
+sequences are in contention over shared locks.
+
+The current arbitration implementation is based on random ordering of the queued
+sequences (i.e. everything currently waiting on a `async with ctx.lock(...)` call).
+Future improvements to Forastero will introduce more complex arbitration functions
+that allow control over the balancing of different sequences.

--- a/forastero/bench.py
+++ b/forastero/bench.py
@@ -29,6 +29,7 @@ from cocotb.clock import Clock
 from cocotb.handle import HierarchyObject, ModifiableObject
 from cocotb.log import SimLog, SimLogFormatter, SimTimeContextFilter
 from cocotb.result import SimTimeoutError
+from cocotb.task import Task
 from cocotb.triggers import ClockCycles, Event, with_timeout
 
 from .component import Component
@@ -233,19 +234,21 @@ class BaseBench:
         else:
             raise TypeError(f"Unsupported object: {comp_or_coro}")
 
-    def schedule(self, sequence: BaseSequence, blocking: bool = True) -> None:
+    def schedule(self, sequence: BaseSequence, blocking: bool = True) -> Task:
         """
         Schedule a sequence to execute as part of a testcase.
 
         :param sequence: The sequence to schedule
         :param blocking: Whether the sequence must complete before the test is
                          allowed to finish
+        :returns:        The scheduled task
         """
         task = cocotb.start_soon(
             sequence(self.fork_log("sequence"), self.random, self._arbiter)
         )
         if blocking:
             self._sequences.append(task)
+        return task
 
     def add_teardown(self, coro: Coroutine) -> None:
         """

--- a/forastero/sequence.py
+++ b/forastero/sequence.py
@@ -330,7 +330,7 @@ class SeqContext:
                 need.append(lock)
         # Queue against the arbiter for a slot to execute
         await self._arbiter.queue_for(self, need)
-        # Yield back to the
+        # Yield to allow the sequence to execute
         yield
         # Release any remaining locks
         self.log.debug(f"Releasing {len(lockables)} locks")

--- a/forastero/sequence.py
+++ b/forastero/sequence.py
@@ -211,7 +211,7 @@ class SeqArbiter:
         :param context: The sequence context queueing
         :param locks:   The list of locks required
         """
-        self._log.info(f"Sequence context {context._sequence.name} began queueing")
+        self._log.debug(f"Sequence context {context._sequence.name} began queueing")
         # Queue up the context, locks it requests, and the stall event
         self._queue.append((context, locks, evt := Event()))
         # Mark a new entry as having been pushed
@@ -219,7 +219,7 @@ class SeqArbiter:
         # Wait for the event
         await evt.wait()
         # Log that the sequence has been released
-        self._log.info(
+        self._log.debug(
             f"Sequence context {context._sequence.name} has finished queueing"
         )
 
@@ -240,7 +240,7 @@ class SeqArbiter:
                 order = list(range(len(self._queue)))
                 self._random.shuffle(order)
                 # Schedule as many sequences as possible
-                self._log.info(
+                self._log.debug(
                     f"Attempting to schedule {len(self._queue)} sequences "
                     f"with {len(available)} available locks"
                 )
@@ -262,7 +262,7 @@ class SeqArbiter:
                     # If no more locks are available, break out early
                     if not available:
                         break
-                self._log.info(f"Scheduled {len(scheduled)} sequences")
+                self._log.debug(f"Scheduled {len(scheduled)} sequences")
                 # Prune the scheduled sequences
                 self._queue = [
                     x for i, x in enumerate(self._queue) if i not in scheduled

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,5 +39,6 @@ nav:
     - Components: "classes/component.md"
     - BaseDriver: "classes/driver.md"
     - BaseMonitor: "classes/monitor.md"
+    - Sequences: "classes/sequences.md"
     - Scoreboards: "classes/scoreboard.md"
     - Testbenches: "classes/bench.md"


### PR DESCRIPTION
Implementing `SeqArbiter` which acts as a centralised arbiter for sequences awaiting locks. In this initial implementation, arbitration is based entirely on random selection. Future improvements to Forastero will introduce more control over the arbitration function and sequence waiting.