### PR TITLE
Improvements to sequences

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -131,6 +131,28 @@ Note that `tb.stream_init` refers to the instance of `StreamInitiator` that was
 registered onto the testbench in the previous example. The `for` loop then
 generates a number of `StreamTransaction` objects carrying random data.
 
+Drivers can return an event to allow a test or sequence to determine when a
+particular transaction reaches a pre or post-drive state. When `wait_for` is
+provided, the `enqueue` function will return a cocotb `Event`, and this can be
+awaited:
+
+```python title="tb/testcases/random.py"
+from cocotb.log import SimLog
+
+from forastero.driver import DriverEvent
+
+from ..stream import StreamTransaction
+from ..testbench import Testbench
+
+@Testbench.testcase()
+async def random(tb: Testbench, log: SimLog):
+    for _ in range(100):
+        await tb.stream_init.enqueue(
+            StreamTransaction(data=tb.random.getrandbits(32)),
+            wait_for=DriverEvent.POST_DRIVE
+        ).wait()
+```
+
 ## Monitors
 
 Monitors inherit from [BaseMonitor](./classes/monitor.md) and must implement the

--- a/example/testbench/testcases/sequences.py
+++ b/example/testbench/testcases/sequences.py
@@ -92,7 +92,7 @@ async def random_backpressure(
                     )[0],
                     cycles=ctx.random.randint(min_interval, max_interval),
                 ),
-                DriverEvent.PRE_DRIVE
+                DriverEvent.PRE_DRIVE,
             ).wait()
 
 

--- a/forastero/__init__.py
+++ b/forastero/__init__.py
@@ -17,7 +17,7 @@ from .driver import BaseDriver, DriverEvent
 from .io import BaseIO, IORole
 from .monitor import BaseMonitor, MonitorEvent
 from .scoreboard import Scoreboard
-from .sequence import requires, sequence
+from .sequence import randarg, requires, sequence
 from .transaction import BaseTransaction
 
 assert all(
@@ -31,6 +31,7 @@ assert all(
         DriverEvent,
         MonitorEvent,
         Scoreboard,
+        randarg,
         requires,
         sequence,
     )

--- a/forastero/driver.py
+++ b/forastero/driver.py
@@ -16,7 +16,7 @@ from enum import Enum, auto
 
 import cocotb
 from cocotb.queue import Queue
-from cocotb.triggers import RisingEdge
+from cocotb.triggers import Event, RisingEdge
 from cocotb.utils import get_sim_time
 
 from .component import Component
@@ -56,18 +56,30 @@ class BaseDriver(Component):
         """Return how many entries are queued up"""
         return self._queue.qsize()
 
-    def enqueue(self, transaction: BaseTransaction) -> None:
+    def enqueue(self,
+                transaction: BaseTransaction,
+                wait_for: DriverEvent | None = None) -> Event | None:
         """
         Queue up a transaction to be driven onto the interface
 
         :param transaction: Transaction to queue, must inherit from BaseTransaction
+        :param wait_for:    When defined, this will return an event that can be
+                            monitored for a given transaction event occurring
         """
+        # Sanity check
         if not isinstance(transaction, BaseTransaction):
             raise TypeError(
                 f"Transaction objects should inherit from "
                 f"BaseTransaction unlike {transaction}"
             )
+        # Does this transaction need an event?
+        if wait_for is not None:
+            transaction._f_event = wait_for
+            transaction._c_event = Event()
+        # Queue up the transaction with no delay
         self._queue.put_nowait(transaction)
+        # Return the cocotb Event (if it was set)
+        return transaction._c_event
 
     async def _driver_loop(self) -> None:
         """Main loop for driving transactions onto the interface"""
@@ -75,14 +87,26 @@ class BaseDriver(Component):
         await RisingEdge(self.clk)
         self._ready.set()
         while True:
+            # Pickup next event to drive
             obj = await self._queue.get()
+            # Wait until reset is deasserted
             while self.rst.value == 1:
                 await RisingEdge(self.clk)
+            # Lock out the driver (prevents shutdown mid-stimulus)
             await self.lock()
+            # Set the timestamp where the transaction was about to be driven
             obj.timestamp = get_sim_time(units="ns")
+            # Notify any pre-drive subscribers
             self.publish(DriverEvent.PRE_DRIVE, obj)
+            if obj._f_event is DriverEvent.PRE_DRIVE:
+                obj._c_event.set()
+            # Drive the transaction
             await self.drive(obj)
+            # Notify any post-drive subscribers
             self.publish(DriverEvent.POST_DRIVE, obj)
+            if obj._f_event is DriverEvent.POST_DRIVE:
+                obj._c_event.set()
+            # Release the lock
             self.release()
 
     async def drive(self, obj: BaseTransaction) -> None:

--- a/forastero/driver.py
+++ b/forastero/driver.py
@@ -56,9 +56,9 @@ class BaseDriver(Component):
         """Return how many entries are queued up"""
         return self._queue.qsize()
 
-    def enqueue(self,
-                transaction: BaseTransaction,
-                wait_for: DriverEvent | None = None) -> Event | None:
+    def enqueue(
+        self, transaction: BaseTransaction, wait_for: DriverEvent | None = None
+    ) -> Event | None:
         """
         Queue up a transaction to be driven onto the interface
 

--- a/forastero/event.py
+++ b/forastero/event.py
@@ -88,8 +88,12 @@ class EventEmitter:
         for event in events:
             event.set(data=obj)
 
-    async def wait_for(self, event: Enum) -> Any:
+    def get_wait_event(self, event: Enum) -> Event:
         evt = Event()
         self._waiting[event].append(evt)
+        return evt
+
+    async def wait_for(self, event: Enum) -> Any:
+        evt = self.get_wait_event(event)
         await evt.wait()
         return evt.data

--- a/forastero/transaction.py
+++ b/forastero/transaction.py
@@ -13,19 +13,30 @@
 # limitations under the License.
 
 import dataclasses
+from enum import Enum
 from typing import Any, Optional
 
 from cocotb.utils import get_sim_time
+from cocotb.triggers import Event
 from tabulate import tabulate
 
 
 @dataclasses.dataclass(kw_only=True)
 class BaseTransaction:
-    """Base transaction object type"""
+    """
+    Base transaction object type
+
+    :param timestamp: The time at which the event occurred
+    :param _f_event:  Forastero event type to trigger on
+    :param _c_event:  The cocotb Event to trigger when _f_event is reached
+    """
 
     timestamp: int = dataclasses.field(
         default_factory=lambda: get_sim_time(units="ns"), compare=False
     )
+
+    _f_event: Enum | None = dataclasses.field(default=None, compare=False)
+    _c_event: Event | None = dataclasses.field(default=None, compare=False)
 
     def format(self, field: str, value: Any) -> str:
         """
@@ -61,6 +72,8 @@ class BaseTransaction:
         # Assemble rows
         rows = []
         for field in dataclasses.fields(self):
+            if field.name in ("_f_event", "_c_event"):
+                continue
             a_val = self.format(field.name, getattr(self, field.name))
             cols = [field.name, a_val]
             if other is not None:

--- a/forastero/transaction.py
+++ b/forastero/transaction.py
@@ -16,8 +16,8 @@ import dataclasses
 from enum import Enum
 from typing import Any, Optional
 
-from cocotb.utils import get_sim_time
 from cocotb.triggers import Event
+from cocotb.utils import get_sim_time
 from tabulate import tabulate
 
 


### PR DESCRIPTION
This PR makes further improvements to sequences:

 * Fixes a further bug in the arbiter's scheduling mechanism where it could deadlock;
 * Adds the ability to declare `@forastero.randarg()` to randomise sequence arguments;
 * Adds the ability to provide `wait_for` to `enqueue` in order to wait for a transaction to reach a given state.

Documentation and example code updated to detail and demonstrate these.