### PR TITLE
Adding postmortem mode to scoreboard/testbench failures

### DIFF
--- a/examples/arbiter/testbench/testbench.py
+++ b/examples/arbiter/testbench/testbench.py
@@ -50,9 +50,7 @@ class Testbench(BaseBench):
         # Register drivers and monitors for the stream interfaces
         self.register("a_init", StreamInitiator(self, a_io, self.clk, self.rst))
         self.register("b_init", StreamInitiator(self, b_io, self.clk, self.rst))
-        self.register(
-            "x_resp", StreamResponder(self, x_io, self.clk, self.rst, blocking=False)
-        )
+        self.register("x_resp", StreamResponder(self, x_io, self.clk, self.rst, blocking=False))
         self.register(
             "x_mon",
             StreamMonitor(self, x_io, self.clk, self.rst),
@@ -63,9 +61,7 @@ class Testbench(BaseBench):
         self.a_init.subscribe(DriverEvent.POST_DRIVE, self.model)
         self.b_init.subscribe(DriverEvent.POST_DRIVE, self.model)
 
-    def model(
-        self, driver: StreamInitiator, event: DriverEvent, obj: StreamTransaction
-    ) -> None:
+    def model(self, driver: StreamInitiator, event: DriverEvent, obj: StreamTransaction) -> None:
         """
         Demonstration model that forwards transactions seen on interfaces A & B
         and sets bit 32 (to match the filtering behaviour below)

--- a/examples/arbiter/testbench/testcases/sequences.py
+++ b/examples/arbiter/testbench/testcases/sequences.py
@@ -79,8 +79,7 @@ async def random_seq(
     tb.schedule(stream_traffic_seq(stream=tb.b_init, length=single_pkts))
     # Schedule isolated bursts of packets on upstream interfaces A & B
     log.info(
-        f"Scheduling {burst_count} bursts between {burst_min} and {burst_max} "
-        f"packets in length"
+        f"Scheduling {burst_count} bursts between {burst_min} and {burst_max} " f"packets in length"
     )
     for _ in range(burst_count):
         tb.schedule(

--- a/forastero/bench.py
+++ b/forastero/bench.py
@@ -320,9 +320,7 @@ class BaseBench:
             # All drivers and monitors should be idle
             self._orch_log.info(f"Shutdown loop ({loop_idx+1}/{loops})")
             # Wait for sequences to complete
-            self._orch_log.debug(
-                f"Waiting for {len(self._sequences)} sequences to complete"
-            )
+            self._orch_log.debug(f"Waiting for {len(self._sequences)} sequences to complete")
             for sequence in self._sequences:
                 await sequence
             # Wait for minimum delay
@@ -384,8 +382,7 @@ class BaseBench:
                         tb = cls(dut)
                     except Exception as e:
                         dut._log.error(
-                            f"Caught exception during {cls.__name__} constuction: "
-                            f"{e}"
+                            f"Caught exception during {cls.__name__} constuction: " f"{e}"
                         )
                         dut._log.error(traceback.format_exc())
                         raise e
@@ -401,14 +398,10 @@ class BaseBench:
                                 f"not been registered with the testbench"
                             )
                             missing += 1
-                    assert (
-                        missing == 0
-                    ), "Some bench components have not been registered"
+                    assert missing == 0, "Some bench components have not been registered"
                     # If clock driving specified, start the clock
                     if tb.clk_drive:
-                        cocotb.start_soon(
-                            Clock(tb.clk, tb.clk_period, units=tb.clk_units).start()
-                        )
+                        cocotb.start_soon(Clock(tb.clk, tb.clk_period, units=tb.clk_units).start())
                     # If reset requested, run the sequence
                     if reset:
                         tb._orch_log.info("Resetting the DUT")
@@ -439,9 +432,7 @@ class BaseBench:
                     params = {}
                     for key in cls.TEST_REQ_PARAMS[self._func]:
                         # First look for "<TESTCASE_NAME>.<PARAMETER_NAME>"
-                        if (
-                            value := raw_tc_params.get(f"{tc_name}.{key}", None)
-                        ) is not None:
+                        if (value := raw_tc_params.get(f"{tc_name}.{key}", None)) is not None:
                             log.debug(f"Parameter {key}={value}")
                             params[key] = value
                         # Fall back to just the parameter name
@@ -464,9 +455,7 @@ class BaseBench:
                             await with_timeout(_inner(), timeout, "ns")
                         except SimTimeoutError as e:
                             postponed = e
-                            tb._orch_log.error(
-                                f"Simulation timed out after {timeout} ns"
-                            )
+                            tb._orch_log.error(f"Simulation timed out after {timeout} ns")
                             # List any busy drivers
                             for name, driver in tb._components.items():
                                 if isinstance(driver, BaseDriver) and driver.queued > 0:
@@ -480,9 +469,8 @@ class BaseBench:
                         channel.report()
 
                     # When using postmortem, catch errors before exit
-                    if (
-                        tb.get_parameter("postmortem", False) and
-                        ((postponed is not None) or not tb.scoreboard.result)
+                    if tb.get_parameter("postmortem", False) and (
+                        (postponed is not None) or not tb.scoreboard.result
                     ):
                         tb._orch_log.warning("Entering postmortem")
                         breakpoint()

--- a/forastero/driver.py
+++ b/forastero/driver.py
@@ -76,8 +76,7 @@ class BaseDriver(Component):
         # Sanity check
         if not isinstance(transaction, BaseTransaction):
             raise TypeError(
-                f"Transaction objects should inherit from "
-                f"BaseTransaction unlike {transaction}"
+                f"Transaction objects should inherit from " f"BaseTransaction unlike {transaction}"
             )
         # Does this transaction need an event?
         if wait_for is not None:

--- a/forastero/io.py
+++ b/forastero/io.py
@@ -257,7 +257,7 @@ class BaseIO:
             raw = int(item.value)
             return (raw == 1) if len(item) == 1 else raw
 
-    def set(self, comp: str, value: Any) -> None:  # noqa: A003
+    def set(self, comp: str, value: Any) -> None:
         """
         Set the value of a particular signal if it exists.
 

--- a/forastero/io.py
+++ b/forastero/io.py
@@ -28,9 +28,7 @@ class IORole(IntEnum):
 
     @staticmethod
     def opposite(value: "IntEnum") -> "IntEnum":
-        return {IORole.INITIATOR: IORole.RESPONDER, IORole.RESPONDER: IORole.INITIATOR}[
-            value
-        ]
+        return {IORole.INITIATOR: IORole.RESPONDER, IORole.RESPONDER: IORole.INITIATOR}[value]
 
 
 class SignalWrapper:
@@ -89,9 +87,7 @@ class SignalWrapper:
         return self._width
 
 
-def io_prefix_style(
-    bus: str | None, component: str, role_bus: IORole, role_comp: IORole
-) -> str:
+def io_prefix_style(bus: str | None, component: str, role_bus: IORole, role_comp: IORole) -> str:
     """
     Style signal names as i/o_(<BUS>_)<COMPONENT> for example i_dma_awaddr and
     o_dma_awready.
@@ -114,9 +110,7 @@ def io_prefix_style(
     return f"{full_name}_{component}"
 
 
-def io_suffix_style(
-    bus: str | None, component: str, role_bus: IORole, role_comp: IORole
-) -> str:
+def io_suffix_style(bus: str | None, component: str, role_bus: IORole, role_comp: IORole) -> str:
     """
     Style signal names as (<BUS>_)<COMPONENT>_i/o for example dma_awaddr_i and
     dma_awready_o.
@@ -137,9 +131,7 @@ def io_suffix_style(
     return f"{full_name}{component}_{mapping[role_bus, role_comp]}"
 
 
-def io_plain_style(
-    bus: str | None, component: str, role_bus: IORole, role_comp: IORole
-) -> str:
+def io_plain_style(bus: str | None, component: str, role_bus: IORole, role_comp: IORole) -> str:
     """
     Style signal names as (<BUS>_)<COMPONENT> for example dma_awaddr and
     dma_awready.
@@ -229,9 +221,7 @@ class BaseIO:
 
     def initialise(self, role: IORole) -> None:
         """Initialise signals according to the active role"""
-        for sig in (
-            self.__initiators if role == IORole.INITIATOR else self.__responders
-        ).values():
+        for sig in (self.__initiators if role == IORole.INITIATOR else self.__responders).values():
             sig.value = 0
 
     def set_default(self, comp: str, value: Any) -> None:
@@ -267,7 +257,7 @@ class BaseIO:
             raw = int(item.value)
             return (raw == 1) if len(item) == 1 else raw
 
-    def set(self, comp: str, value: Any) -> None:
+    def set(self, comp: str, value: Any) -> None:  # noqa: A003
         """
         Set the value of a particular signal if it exists.
 

--- a/forastero/scoreboard.py
+++ b/forastero/scoreboard.py
@@ -400,9 +400,7 @@ class FunnelChannel(Channel):
             self.log.info(self._q_mon.peek().tabulate())
         for key, queue in self._q_ref.items():
             if queue.level > 0:
-                self.log.info(
-                    f"Packet at head of {self.name}'s reference queue '{key}':"
-                )
+                self.log.info(f"Packet at head of {self.name}'s reference queue '{key}':")
                 self.log.info(queue.peek().tabulate())
 
 
@@ -437,10 +435,10 @@ class Scoreboard:
 
     def __init__(
         self,
-        tb: "BaseBench",
+        tb,
         fail_fast: bool = False,
         postmortem: bool = False,
-    ):  # noqa: F821
+    ):
         self.fail_fast = fail_fast
         self.postmortem = postmortem
         self._mismatches = []
@@ -474,7 +472,7 @@ class Scoreboard:
                            in the monitor queue in nanoseconds (defaults to 100 ns)
         """
         assert monitor.name not in self.channels, f"Monitor known for '{monitor.name}'"
-        if isinstance(queues, (list, tuple)) and len(queues) > 0:
+        if isinstance(queues, list | tuple) and len(queues) > 0:
             channel = FunnelChannel(
                 monitor.name,
                 monitor,
@@ -546,8 +544,7 @@ class Scoreboard:
         :param reference: The reference transaction produced by a model
         """
         self.log.info(
-            f"Match on channel {channel.monitor.name} for transaction index "
-            f"{channel.total-1}"
+            f"Match on channel {channel.monitor.name} for transaction index " f"{channel.total-1}"
         )
         self.log.info(monitor.tabulate(reference))
 

--- a/forastero/sequence.py
+++ b/forastero/sequence.py
@@ -160,13 +160,9 @@ class SeqRandomVariable:
         self.choices = choices
         # Sanity checks
         assert len(name) > 0, "Variable name cannot be an empty string"
-        assert not name.endswith(
-            "_bitwidth"
-        ), "Variable name must not end with '_bitwidth'"
+        assert not name.endswith("_bitwidth"), "Variable name must not end with '_bitwidth'"
         assert not name.endswith("_range"), "Variable name must not end with '_range'"
-        assert not name.endswith(
-            "_choices"
-        ), "Variable name must not end with '_choices'"
+        assert not name.endswith("_choices"), "Variable name must not end with '_choices'"
         assert (
             len([x for x in (bit_width, range, choices) if x is not None]) <= 1
         ), "Only one of bit width, range, or choices may be specified"
@@ -343,9 +339,7 @@ class SeqArbiter:
             # Wait until something is queued up
             await self._evt_queue.wait()
             # Log scheduling is starting
-            log.debug(
-                f"Starting scheduling pass {idx} with {SeqLock.count_all_locks()} locks"
-            )
+            log.debug(f"Starting scheduling pass {idx} with {SeqLock.count_all_locks()} locks")
             # While stuff is queued, attempt to schedule it
             while self._queue:
                 # Keep track of which locks are available
@@ -381,13 +375,9 @@ class SeqArbiter:
                     # If no more locks are available, break out early
                     if not available:
                         break
-                log.debug(
-                    f"Scheduled {len(scheduled)} sequences, {len(locks)} locks remain"
-                )
+                log.debug(f"Scheduled {len(scheduled)} sequences, {len(locks)} locks remain")
                 # Prune the scheduled sequences
-                self._queue = [
-                    x for i, x in enumerate(self._queue) if i not in scheduled
-                ]
+                self._queue = [x for i, x in enumerate(self._queue) if i not in scheduled]
                 # If scheduling was unsuccessful then either wait for locks to
                 # be released or new sequences to be scheduled
                 # NOTE: As the scheduling loop contains an `await` it is
@@ -399,9 +389,7 @@ class SeqArbiter:
                     # Clear trigger event so that the next queue_for raises it
                     self._evt_queue.clear()
                     await First(
-                        SeqContext.SEQ_SHARED_EVENT.get_wait_event(
-                            SeqContextEvent.UNLOCKED
-                        ).wait(),
+                        SeqContext.SEQ_SHARED_EVENT.get_wait_event(SeqContextEvent.UNLOCKED).wait(),
                         self._evt_queue.wait(),
                     )
             # Log at the end of this pass
@@ -449,7 +437,7 @@ class SeqContext:
         self._locks_active = False
 
     @property
-    def id(self) -> str:
+    def id(self) -> str:  # noqa: A003
         return f"{self._sequence.name}[{self._ctx_id}]"
 
     @contextlib.asynccontextmanager
@@ -463,9 +451,7 @@ class SeqContext:
                            will be resolved to the equivalent component locks)
         """
         # Mark that locking is active
-        assert (
-            not self._locks_active
-        ), "You must release all locks before re-acquisition"
+        assert not self._locks_active, "You must release all locks before re-acquisition"
         self._locks_active = True
         # Figure out all the locks that need to be acquired
         need: list[SeqLock] = []
@@ -479,9 +465,7 @@ class SeqContext:
         # Yield to allow the sequence to execute
         yield
         # Release any remaining locks
-        self.log.debug(
-            f"Releasing {len(lockables)} locks: " + ", ".join(x._name for x in need)
-        )
+        self.log.debug(f"Releasing {len(lockables)} locks: " + ", ".join(x._name for x in need))
         for lock in need:
             if lock._locked_by is self:
                 lock.release(self)
@@ -560,12 +544,8 @@ class BaseSequence:
         """
         req_name = req_name.strip().lower().replace(" ", "_")
         assert len(req_name) > 0, "Requirement name cannot be an empty string"
-        assert (
-            req_name not in self._requires
-        ), f"Requirement already placed on {req_name}"
-        assert (
-            req_name not in self._locks
-        ), f"Requirement {req_name} clashes with a lock"
+        assert req_name not in self._requires, f"Requirement already placed on {req_name}"
+        assert req_name not in self._locks, f"Requirement {req_name} clashes with a lock"
         self._requires[req_name] = req_type
         return self
 
@@ -580,12 +560,8 @@ class BaseSequence:
         """
         lock_name = lock_name.strip().lower().replace(" ", "_")
         assert len(lock_name) > 0, "Lock name cannot be an empty string"
-        assert (
-            lock_name not in self._locks
-        ), f"Lock '{lock_name}' has already been defined"
-        assert (
-            lock_name not in self._requires
-        ), f"Lock {lock_name} clashes with a requirement"
+        assert lock_name not in self._locks, f"Lock '{lock_name}' has already been defined"
+        assert lock_name not in self._requires, f"Lock {lock_name} clashes with a requirement"
         self._locks.append(lock_name)
         return self
 
@@ -640,9 +616,7 @@ class BaseSequence:
                 match = kwds[name]
                 del kwds[name]
                 if not isinstance(match, ctype):
-                    raise Exception(
-                        f"Component '{name}' is not of type {ctype.__name__}"
-                    )
+                    raise Exception(f"Component '{name}' is not of type {ctype.__name__}")
                 # Ensure a component lock exists
                 comp_lock = SeqLock.get_component_lock(match)
                 # Pickup the component and wrap it in a proxy

--- a/forastero/sequence.py
+++ b/forastero/sequence.py
@@ -437,7 +437,7 @@ class SeqContext:
         self._locks_active = False
 
     @property
-    def id(self) -> str:  # noqa: A003
+    def id(self) -> str:
         return f"{self._sequence.name}[{self._ctx_id}]"
 
     @contextlib.asynccontextmanager

--- a/forastero/transaction.py
+++ b/forastero/transaction.py
@@ -49,6 +49,8 @@ class BaseTransaction:
         """
         if field == "timestamp":
             return f"{value} ns"
+        elif isinstance(value, Enum):
+            return f"{value.name} ({int(value)})"
         elif isinstance(value, int):
             return f"0x{value:X}"
         else:

--- a/forastero/transaction.py
+++ b/forastero/transaction.py
@@ -38,7 +38,7 @@ class BaseTransaction:
     _f_event: Enum | None = dataclasses.field(default=None, compare=False)
     _c_event: Event | None = dataclasses.field(default=None, compare=False)
 
-    def format(self, field: str, value: Any) -> str:
+    def format(self, field: str, value: Any) -> str:  # noqa: A003
         """
         Subclasses of BaseTransaction may override this to format different
         fields however they prefer.

--- a/forastero/transaction.py
+++ b/forastero/transaction.py
@@ -38,7 +38,7 @@ class BaseTransaction:
     _f_event: Enum | None = dataclasses.field(default=None, compare=False)
     _c_event: Event | None = dataclasses.field(default=None, compare=False)
 
-    def format(self, field: str, value: Any) -> str:  # noqa: A003
+    def format(self, field: str, value: Any) -> str:
         """
         Subclasses of BaseTransaction may override this to format different
         fields however they prefer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,6 @@ pytest = "^8.1.1"
 target-version = "py311"
 # Character length of 88 is compatible with Black
 line-length = 100
-
-[tool.ruff.lint]
 fixable = ["ALL"]
 unfixable = []
 # See https://beta.ruff.rs/docs/rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,27 +22,20 @@ yappi = "^1.6.0"
 mkdocs = "^1.6.0"
 mkdocs-material = "^9.5.31"
 mkdocstrings = {extras = ["python"], version = "^0.25.2"}
-ruff = "^0.5.7"
+ruff = "^0.7.2"
 pre-commit = "^3.6.2"
 pytest = "^8.1.1"
 
 [tool.ruff]
-line-length = 88
-indent-width = 4
-
-# Assume Python 3.11
 target-version = "py311"
+# Character length of 88 is compatible with Black
+line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "B", "UP", "N", "W", "I", "A", "C4", "PTH", "RUF"]
-ignore = []
 fixable = ["ALL"]
 unfixable = []
-
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-skip-magic-trailing-comma = false
-line-ending = "auto"
-docstring-code-format = true
-docstring-code-line-length = "dynamic"
+# See https://beta.ruff.rs/docs/rules
+select = ["E", "F", "B", "UP", "N", "W", "I", "A", "C4", "PTH", "RUF"]
+ignore = [
+    "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ pytest = "^8.1.1"
 target-version = "py311"
 # Character length of 88 is compatible with Black
 line-length = 100
+
+[tool.ruff.lint]
 fixable = ["ALL"]
 unfixable = []
 # See https://beta.ruff.rs/docs/rules


### PR DESCRIPTION
A number of small tweaks to make debugging testbenches a little nicer:

 * Adding `postmortem` option - this activates a breakpoint after mismatches and other failure conditions to help debug;
 * Making scoreboard queues a little easier to work with (support `len(...)` and `_q_ref[...]` access);
 * Allowing multi-queue scoreboard channels to be described with a tuple;
 * Printing enum name when tabulating a mismatch. 