### PR TITLE
Scoreboard verbosity now based on logging levels

### DIFF
--- a/forastero/bench.py
+++ b/forastero/bench.py
@@ -222,7 +222,6 @@ class BaseBench:
         name: str,
         comp_or_coro: Component | Coroutine = None,
         scoreboard: bool = True,
-        scoreboard_verbose: bool = False,
         scoreboard_queues: list[str] | None = None,
         scoreboard_filter: Callable | None = None,
         scoreboard_timeout_ns: int | None = None,
@@ -239,9 +238,6 @@ class BaseBench:
         :param comp_or_coro:          Component instance or coroutine
         :param scoreboard:            Only applies to monitors, controls whether
                                       it is registered with the scoreboard
-        :param scoreboard_verbose:    Only applies to scoreboarded monitors,
-                                      controls whether to log each transaction,
-                                      even when they don't mismatch
         :param scoreboard_queues:     A list of named queues used when a funnel
                                       type scoreboard channel is required
         :param scoreboard_filter:     A function that can filter or modify items
@@ -269,7 +265,6 @@ class BaseBench:
             if scoreboard and isinstance(comp_or_coro, BaseMonitor):
                 self.scoreboard.attach(
                     comp_or_coro,
-                    verbose=scoreboard_verbose,
                     filter_fn=scoreboard_filter,
                     queues=scoreboard_queues,
                     timeout_ns=scoreboard_timeout_ns,

--- a/forastero/scoreboard.py
+++ b/forastero/scoreboard.py
@@ -14,11 +14,11 @@
 
 from collections.abc import Callable
 from typing import Any
-
 import cocotb
 from cocotb.log import SimLog
 from cocotb.triggers import Event, First, Lock, RisingEdge, Timer
 from cocotb.utils import get_sim_time
+import logging
 
 from .monitor import BaseMonitor, MonitorEvent
 from .transaction import BaseTransaction
@@ -449,7 +449,6 @@ class Scoreboard:
     def attach(
         self,
         monitor: BaseMonitor,
-        verbose=False,
         filter_fn: Callable | None = None,
         queues: list[str] | tuple[str] | None = None,
         timeout_ns: int | None = None,
@@ -460,7 +459,6 @@ class Scoreboard:
         channel in the process.
 
         :param monitor:    The monitor to attach
-        :param verbose:    Whether to tabulate matches as well as mismatches
         :param queues:     List of reference queue names, this causes a funnel
                            type scoreboard channel to be used
         :param filter_fn:  A filter function that can either drop or modify items
@@ -492,7 +490,7 @@ class Scoreboard:
                 polling_ns=polling_ns,
             )
         self.channels[channel.name] = channel
-        if verbose:
+        if self.log.getEffectiveLevel() <= logging.DEBUG:
             cocotb.start_soon(channel.loop(self._mismatch, self._match))
         else:
             cocotb.start_soon(channel.loop(self._mismatch))
@@ -537,16 +535,16 @@ class Scoreboard:
     ) -> None:
         """
         Callback whenever a channel detects a match between captured and
-        reference objects, only called if monitor attached with `verbose`.
+        reference objects, only called if monitor attached with DEBUG verbosity.
 
         :param channel:   The channel reporting the mismatch
         :param monitor:   The transaction captured by a monitor
         :param reference: The reference transaction produced by a model
         """
-        self.log.info(
+        self.log.debug(
             f"Match on channel {channel.monitor.name} for transaction index " f"{channel.total-1}"
         )
-        self.log.info(monitor.tabulate(reference))
+        self.log.debug(monitor.tabulate(reference))
 
     @property
     def result(self) -> bool:

--- a/forastero/scoreboard.py
+++ b/forastero/scoreboard.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from collections.abc import Callable
 from typing import Any
+
 import cocotb
 from cocotb.log import SimLog
 from cocotb.triggers import Event, First, Lock, RisingEdge, Timer
 from cocotb.utils import get_sim_time
-import logging
 
 from .monitor import BaseMonitor, MonitorEvent
 from .transaction import BaseTransaction


### PR DESCRIPTION
Scoreboard verbosity is now based on logging levels, rather than 'verbose' parameter.

Matches are now only tabulated if the logging level is DEBUG or lower