### PR TITLE
Refining internal logging

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on        : ubuntu-latest
     timeout-minutes: 15
     steps          :
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name : Install Poetry and environment
@@ -51,4 +51,4 @@ jobs:
     steps          :
       - name: Deploy to GitHub pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps          :
       - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name : Install Poetry and environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on        : ubuntu-latest
     timeout-minutes: 15
     steps          :
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name : Setup Icarus Verilog

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -8,10 +8,8 @@ is in itself an extension of Python's built-in
 Forastero provides the following levels of hierarchy:
 
  * `tb` - the root of the logging hierarchy;
- * `tb.orchestration` - used for log messages to do with testbench sequencing
-   (e.g. used when draining different drivers and monitors at the end of a test);
  * `tb.scoreboard` - used for messages emitted from the scoreboard;
- * `tb.scoreboard.channels.<X>` - used for messages emitted from a particular
+ * `tb.scoreboard.channel.<X>` - used for messages emitted from a particular
    scoreboard channel;
  * `tb.driver.<X>` - used for messages emitted from a particular driver (when
    extending from [BaseDriver](./classes/driver.md));
@@ -19,9 +17,15 @@ Forastero provides the following levels of hierarchy:
    extending from [BaseMonitor](./classes/monitor.md));
  * `tb.io.<X>` - used for messages emitted from a particular I/O wrapper class
    (when extending from [BaseIO](./classes/io.md));
- * `tb.testcase.<X>` - used for messages emitted from a particular testcase;
- * `tb.arbiter` - used for messages emitted from the sequencing arbiter;
- * `tb.sequence.<X>` - used for messages emitted from a specific sequence.
+ * `tb.test.<X>` - used for messages emitted from a particular testcase;
+ * `tb.seq.<X>` - used for messages emitted from a specific sequence;
+ * `tb.int` - is used for internal messages from the framework to do with the
+   control and sequencing of tests:
+   * `tb.int.orch` - used for log messages to do with testbench orchestration
+     (e.g. used when draining different drivers and monitors at the end of a
+     test);
+   * `tb.int.seq` - used for internal messages related to sequence scheduling,
+     arbitration, and execution.
 
 These logging contexts are created using the `fork_log` method of
 [BaseBench](./classes/bench.md). If you want to introduce custom layers of

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -8,8 +8,8 @@ the behaviour of testcases, an example of its structure is shown below:
     "seed": 1234,
     "verbosity": {
         "tb": "info",
-        "tb.orchestration": "debug",
-        "tb.testcase.my_testcase": "warning"
+        "tb.int": "debug",
+        "tb.test.my_testcase": "warning"
     },
     "profiling": "/path/to/store/profiling.stats",
     "fail_fast": true,
@@ -23,9 +23,9 @@ the behaviour of testcases, an example of its structure is shown below:
  * `seed` - sets the random number seeding value for the `tb.random` instance;
  * `verbosity` - control the verbosity of different logging hierarchies:
    * `tb` - sets the global verbosity;
-   * `tb.orchestration` - sets the verbosity of Forastero's internal orchestration
-     methods (i.e. those controlling test setup and teardown);
-   * `tb.testcase.my_testcase` - sets the verbosity for a given testcase;
+   * `tb.int` - sets the verbosity of Forastero's internal orchestration and
+     scheduling methods (i.e. those controlling test setup and teardown);
+   * `tb.test.my_testcase` - sets the verbosity for a given testcase;
    * More information can be found in the [logging](./logging.md) documentation.
  * `profiling` - when included this enables [YAPPI](https://pypi.org/project/yappi/)
    profiling of the testbench and writes the profiling data to the given file

--- a/examples/arbiter/Makefile
+++ b/examples/arbiter/Makefile
@@ -36,6 +36,7 @@ MODULE   = testbench
 ACCUM_PY_PATH += $(PYTHONPATH)
 ACCUM_PY_PATH += $(THIS_DIR)
 ACCUM_PY_PATH += $(abspath $(THIS_DIR)/..)
+ACCUM_PY_PATH += $(abspath $(THIS_DIR)/../..)
 export PYTHONPATH := $(subst $(SPACE),:,$(ACCUM_PY_PATH))
 
 # Parameters file

--- a/examples/arbiter/params.json
+++ b/examples/arbiter/params.json
@@ -1,7 +1,7 @@
 {
     "verbosity": {
         "tb": "info",
-        "tb.arbiter": "info"
+        "tb.int.seq": "info"
     },
     "seed": 1234,
     "fail_fast": true,

--- a/forastero/bench.py
+++ b/forastero/bench.py
@@ -116,7 +116,7 @@ class BaseBench:
             logging.getLogger(hierarchy).setLevel(getattr(logging, verbosity.upper()))
         # Create a child log for orchestration
         # NOTE: This should really only be used by internal testbench processes
-        self._orch_log = self.fork_log("orchestration")
+        self._orch_log = self.fork_log("int", "orch")
         # Create a scoreboard
         self.scoreboard = Scoreboard(
             tb=self,
@@ -132,7 +132,7 @@ class BaseBench:
         self.info(f"Bench initialised with random seed {self.seed}")
         self.random = random.Random(self.seed)
         # Sequence handling
-        self._arbiter = SeqArbiter(self.fork_log("arbiter"), self.random)
+        self._arbiter = SeqArbiter(self.fork_log("int", "seq"), self.random)
         self._sequences = []
         # Events
         self.evt_ready = Event()
@@ -285,7 +285,7 @@ class BaseBench:
         """
         task = cocotb.start_soon(
             sequence(
-                self.fork_log("sequence"),
+                self.fork_log("seq"),
                 self.random,
                 self._arbiter,
                 self.clk,
@@ -430,7 +430,7 @@ class BaseBench:
                         await comp.ready()
 
                     # Create a forked log
-                    log = tb.fork_log("testcase", tc_name)
+                    log = tb.fork_log("test", tc_name)
 
                     # Are there any parameters for this test?
                     raw_tc_params = cls.get_parameter("testcases")

--- a/forastero/scoreboard.py
+++ b/forastero/scoreboard.py
@@ -475,7 +475,7 @@ class Scoreboard:
             channel = FunnelChannel(
                 monitor.name,
                 monitor,
-                self.tb.fork_log("channel", monitor.name),
+                self.tb.fork_log("scoreboard", "channel", monitor.name),
                 filter_fn,
                 queues,
                 timeout_ns=timeout_ns,
@@ -485,7 +485,7 @@ class Scoreboard:
             channel = Channel(
                 monitor.name,
                 monitor,
-                self.tb.fork_log("channel", monitor.name),
+                self.tb.fork_log("scoreboard", "channel", monitor.name),
                 filter_fn,
                 timeout_ns=timeout_ns,
                 polling_ns=polling_ns,


### PR DESCRIPTION
 * Number of messages emitted from sequence arbitration are significantly reduced
 * A number of logging hierarchies relocated under `tb.int` for "internal" messages to make it easier to bulk-suppress (e.g. `tb.int.orch` for orchestration and `tb.int.seq` for sequence scheduling)
 * Scoreboard channels correctly relocated under `tb.scoreboard.channel` (where the docs say it should be)
 * Docs updated to reflect new structure
 * GitHub actions updated to new versions (doc publish was using a deprecated version)