### PR TITLE
Allowing the drain policy of the scoreboard to be set

### DIFF
--- a/docs/components/monitor.md
+++ b/docs/components/monitor.md
@@ -164,7 +164,7 @@ class Testbench(BaseBench):
                           self.clk,
                           self.rst,
                       ),
-                      scoreboard_filter=self.filter_mapped_req_mon)
+                      sb_filter=self.filter_mapped_req_mon)
         self.mapped_req_mon.subscribe(MonitorEvent.CAPTURE, self.mapped_capture)
 
     def filter_mapped_req_mon(self,

--- a/forastero/__init__.py
+++ b/forastero/__init__.py
@@ -16,7 +16,7 @@ from .bench import BaseBench
 from .driver import BaseDriver, DriverEvent
 from .io import BaseIO, IORole, io_plain_style, io_prefix_style, io_suffix_style
 from .monitor import BaseMonitor, MonitorEvent
-from .scoreboard import Scoreboard
+from .scoreboard import DrainPolicy, Scoreboard
 from .sequence import SeqContext, SeqLock, SeqProxy, randarg, requires, sequence
 from .transaction import BaseTransaction
 
@@ -28,6 +28,7 @@ assert all(
         BaseIO,
         BaseMonitor,
         BaseTransaction,
+        DrainPolicy,
         DriverEvent,
         MonitorEvent,
         Scoreboard,

--- a/forastero/scoreboard.py
+++ b/forastero/scoreboard.py
@@ -160,8 +160,8 @@ class Channel:
         self.timeout_ns = timeout_ns
         self.polling_ns = polling_ns
         self.drain_policy = drain_policy
-        assert (
-            self.drain_policy in DrainPolicy._value2member_map_
+        assert self.drain_policy in list(
+            DrainPolicy
         ), f"Unsupported draining mode {self.drain_policy}"
         self.match_window = match_window or 1
         assert (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "forastero"
-version = "1.1.0"
+version = "1.1.1"
 description = "cocotb verification framework with the batteries included"
 authors = ["Peter Birch <peter@lightlogic.co.uk>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Adds `DrainPolicy` to control whether the scoreboard pays attention to the reference or monitor queues during shutdown