### PR TITLE
Allowing cocotb 2.0 in pyproject.toml dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["cocotb", "verification", "verilog", "systemverilog"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-cocotb = "^1.9.2"
+cocotb = ">=1.8, <2.1"
 tabulate = "^0.9.0"
 yappi = "^1.6.0"
 


### PR DESCRIPTION
Also allowing cocotb 1.8 (which is compatible)