### PR TITLE
Driver can now enqueue iterables

### DIFF
--- a/examples/arbiter_strict/params.json
+++ b/examples/arbiter_strict/params.json
@@ -8,6 +8,8 @@
     "testcases": {
         "random.packets": 500,
         "random.delay": 6000,
+        "random_iter.packets": 500,
+        "random_iter.delay": 6000,
         "random_seq.single_pkts": 2000,
         "random_seq.burst_count": 10,
         "random_seq.burst_min": 100,

--- a/examples/arbiter_strict/testbench/testcases/__init__.py
+++ b/examples/arbiter_strict/testbench/testcases/__init__.py
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 from .random import *  # noqa: F403
+from .random_iterable import *  # noqa: F403
 from .sequences import *  # noqa: F403
 from .smoke import *  # noqa: F403

--- a/examples/arbiter_strict/testbench/testcases/random_iterable.py
+++ b/examples/arbiter_strict/testbench/testcases/random_iterable.py
@@ -1,0 +1,60 @@
+# Copyright 2023, Peter Birch, mailto:peter@lightlogic.co.uk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from logging import Logger
+
+from cocotb.triggers import ClockCycles
+from common.io.stream import StreamBackpressure, StreamTransaction
+
+from forastero import DriverEvent
+
+from ..testbench import Testbench
+
+
+@Testbench.testcase()
+@Testbench.parameter("packets", int)
+@Testbench.parameter("delay", int)
+async def random_iter(tb: Testbench, log: Logger, packets: int = 1000, delay: int = 5000):
+    # Disable backpressure on input
+    tb.x_resp.enqueue(StreamBackpressure(ready=True))
+
+    # Queue traffic onto interfaces A & B and interleave on the exit port
+    for _ in range(20):
+        tb.a_init.enqueue(StreamTransaction(data=tb.random.getrandbits(32)))
+    tb.a_init.enqueue(init_stimulus_generator(tb, packets))
+    tb.b_init.enqueue(init_stimulus_generator(tb, packets))
+    for _ in range(20):
+        tb.b_init.enqueue(StreamTransaction(data=tb.random.getrandbits(32)))
+
+    # Queue up random backpressure
+    def _rand_bp(*_):
+        tb.x_resp.enqueue(
+            StreamBackpressure(
+                ready=tb.random.choice((True, False)), cycles=tb.random.randint(1, 10)
+            )
+        )
+
+    tb.x_resp.subscribe(DriverEvent.POST_DRIVE, _rand_bp)
+    _rand_bp()
+
+    # Register a long-running coroutine
+    async def _wait():
+        await ClockCycles(tb.clk, delay)
+
+    tb.register("wait", _wait())
+
+
+def init_stimulus_generator(tb, num_packets):
+    for _ in range(num_packets):
+        yield StreamTransaction(data=tb.random.getrandbits(32))

--- a/forastero/driver.py
+++ b/forastero/driver.py
@@ -13,18 +13,19 @@
 # limitations under the License.
 
 import dataclasses
+from collections.abc import Iterable
 from enum import Enum, auto
 from random import Random
 from typing import Any
 
 import cocotb
 from cocotb.handle import SimHandleBase
-from cocotb.queue import Queue
 from cocotb.triggers import Event, RisingEdge
 from cocotb.utils import get_sim_time
 
 from .component import Component
 from .io import BaseIO
+from .queue import Queue
 from .transaction import BaseTransaction
 
 
@@ -40,6 +41,12 @@ class DriverEvent(Enum):
 @dataclasses.dataclass()
 class DriverStatistics:
     dequeued: int = 0
+
+
+@dataclasses.dataclass()
+class EnqueuedIterable:
+    iterable: Iterable
+    wait_for: DriverEvent
 
 
 class BaseDriver(Component):
@@ -73,40 +80,86 @@ class BaseDriver(Component):
     @property
     def busy(self) -> bool:
         """Busy when either locked or the queue has outstanding entries"""
-        return not self._queue.empty() and super().busy
+        return (self._queue.level > 0) and super().busy
 
     @property
     def queued(self) -> int:
         """Return how many entries are queued up"""
-        return self._queue.qsize()
+        return self._queue.level
 
     def enqueue(
-        self, transaction: BaseTransaction, wait_for: DriverEvent | None = None
+        self,
+        transaction: BaseTransaction | Iterable[BaseTransaction],
+        wait_for: DriverEvent | None = None,
     ) -> Event | None:
         """
         Queue up a transaction to be driven onto the interface
 
-        :param transaction: Transaction to queue, must inherit from BaseTransaction
+        :param transaction: Transaction to queue, must inherit from BaseTransaction,
+                            or be an iterable which yields BaseTransaction
         :param wait_for:    When defined, this will return an event that can be
                             monitored for a given transaction event occurring
         """
         # Sanity check
-        if not isinstance(transaction, BaseTransaction):
+        if not isinstance(transaction, BaseTransaction | Iterable):
             raise TypeError(
                 f"Transaction objects should inherit from BaseTransaction unlike {transaction}"
             )
-        # Does this transaction need an event?
-        if wait_for is not None:
-            transaction._f_event = wait_for
-            transaction._c_event = Event()
-        # Queue up the transaction with no delay
-        self._queue.put_nowait(transaction)
-        # Notify any enqueue subscribers
-        self.publish(DriverEvent.ENQUEUE, transaction)
-        if transaction._f_event is DriverEvent.ENQUEUE:
-            transaction._c_event.set()
-        # Return the cocotb Event (if it was set)
-        return transaction._c_event
+        if isinstance(transaction, BaseTransaction):
+            # Does this transaction need an event?
+            if wait_for is not None:
+                transaction._f_event = wait_for
+                transaction._c_event = Event()
+            # Queue up the transaction with no delay
+            self._queue.push(transaction)
+            # Notify any enqueue subscribers
+            self.publish(DriverEvent.ENQUEUE, transaction)
+            if transaction._f_event is DriverEvent.ENQUEUE:
+                transaction._c_event.set()
+            # Return the cocotb Event (if it was set)
+            return transaction._c_event
+        else:
+            # Add wait_for and iterable to a namedTuple
+            transaction = EnqueuedIterable(iterable=transaction, wait_for=wait_for)
+            # Queue up the transaction with no delay
+            self._queue.push(transaction)
+            self.publish(DriverEvent.ENQUEUE, transaction)
+            _c_event = None
+            if wait_for and wait_for._f_event is DriverEvent.ENQUEUE:
+                _c_event = Event()
+                _c_event.set()
+            # Return the cocotb Event (if it was set)
+            return _c_event
+
+    async def get_from_queue(self) -> BaseTransaction:
+        """
+        Fetch next item from the queue.
+        Process iterables and add events to yielded BaseTransaction
+        """
+        while True:
+            await self._queue.wait_for_not_empty()
+            obj = self._queue.peek()
+            if isinstance(obj, BaseTransaction):
+                obj = await self._queue.pop()
+                return obj
+            else:
+                # obj is an EnqueuedIterable - yield from iterable, append events (if any)
+                # and pop from queue when exhausted
+                while True:
+                    try:
+                        if not hasattr(obj, "_iterator"):
+                            obj._iterator = iter(obj.iterable)
+                        next_item = next(obj._iterator)
+                        # If wait_for is set, attach to the transaction
+                        if obj.wait_for is not None and isinstance(next_item, BaseTransaction):
+                            next_item._f_event = obj.wait_for
+                            next_item._c_event = Event()
+                        return next_item
+                    except StopIteration:
+                        # Remove the exhausted EnqueuedIterable from the queue
+                        await self._queue.pop()
+                        # After popping, break to outer loop to process the new front item
+                        break
 
     async def _driver_loop(self) -> None:
         """Main loop for driving transactions onto the interface"""
@@ -115,7 +168,7 @@ class BaseDriver(Component):
         self._ready.set()
         while True:
             # Pickup next event to drive
-            obj = await self._queue.get()
+            obj = await self.get_from_queue()
             # Wait until reset is deasserted
             while self.rst.value == self.tb.rst_active_value:
                 await RisingEdge(self.clk)

--- a/forastero/driver.py
+++ b/forastero/driver.py
@@ -125,7 +125,7 @@ class BaseDriver(Component):
             self._queue.push(transaction)
             self.publish(DriverEvent.ENQUEUE, transaction)
             _c_event = None
-            if wait_for and wait_for._f_event is DriverEvent.ENQUEUE:
+            if wait_for is DriverEvent.ENQUEUE:
                 _c_event = Event()
                 _c_event.set()
             # Return the cocotb Event (if it was set)

--- a/forastero/driver.py
+++ b/forastero/driver.py
@@ -80,7 +80,7 @@ class BaseDriver(Component):
     @property
     def busy(self) -> bool:
         """Busy when either locked or the queue has outstanding entries"""
-        return (self._queue.level > 0) and super().busy
+        return not self._queue.empty and super().busy
 
     @property
     def queued(self) -> int:

--- a/forastero/queue.py
+++ b/forastero/queue.py
@@ -22,7 +22,7 @@ class Queue:
     def __len__(self) -> int:
         return self.level
 
-    def __getitem__(self, key) -> BaseTransaction | list[BaseTransaction]:
+    def __getitem__(self, key) -> Any:
         return self._entries[key]
 
     @property

--- a/forastero/queue.py
+++ b/forastero/queue.py
@@ -2,8 +2,6 @@ from typing import Any
 
 from cocotb.triggers import Event
 
-from .transaction import BaseTransaction
-
 
 class QueueEmptyError(Exception):
     pass
@@ -24,6 +22,10 @@ class Queue:
 
     def __getitem__(self, key) -> Any:
         return self._entries[key]
+
+    @property
+    def empty(self):
+        return len(self._entries) == 0
 
     @property
     def level(self) -> int:

--- a/forastero/queue.py
+++ b/forastero/queue.py
@@ -1,0 +1,74 @@
+from typing import Any
+
+from cocotb.triggers import Event
+
+from .transaction import BaseTransaction
+
+
+class QueueEmptyError(Exception):
+    pass
+
+
+class Queue:
+    """
+    A custom queue implementation that allows peeking onto the head of the queue,
+    which assists with the implementation of funnel-type channels.
+    """
+
+    def __init__(self) -> None:
+        self._entries = []
+        self._on_push = None
+
+    def __len__(self) -> int:
+        return self.level
+
+    def __getitem__(self, key) -> BaseTransaction | list[BaseTransaction]:
+        return self._entries[key]
+
+    @property
+    def level(self) -> int:
+        return len(self._entries)
+
+    @property
+    def on_push_event(self) -> Event:
+        """Expose the event that will be fired on the next push"""
+        if self._on_push is None:
+            self._on_push = Event()
+        return self._on_push
+
+    def push(self, data: Any) -> None:
+        """
+        Push an entry into the queue, notifying any observers that have
+        registered an 'on-push' event.
+
+        :param data: Data to push into the queue
+        """
+        self._entries.append(data)
+        if self._on_push is not None:
+            self._on_push.set()
+        self._on_push = None
+
+    async def pop(self, index: int = 0) -> Any:
+        """
+        Pop an entry from the queue, if necessary blocking until one is available.
+
+        :param index: Index of the item to pop
+        :returns:     Object from the head of the queue
+        """
+        if len(self._entries) == 0:
+            await self.wait()
+        return self._entries.pop(index)
+
+    def wait(self) -> None:
+        """Register an 'on-push' event and wait for it to be set by a push"""
+        return self.on_push_event.wait()
+
+    async def wait_for_not_empty(self) -> None:
+        """Wait until at least one entry exists in the queue"""
+        if self.level == 0:
+            await self.wait()
+
+    def peek(self) -> Any:
+        if len(self._entries) == 0:
+            raise QueueEmptyError()
+        return self._entries[0]

--- a/forastero/scoreboard.py
+++ b/forastero/scoreboard.py
@@ -18,18 +18,14 @@ from collections import defaultdict
 from collections.abc import Callable
 from enum import Enum, auto
 from logging import Logger
-from typing import Any
 
 import cocotb
-from cocotb.triggers import Event, First, RisingEdge, Timer
+from cocotb.triggers import First, RisingEdge, Timer
 from cocotb.utils import get_sim_time
 
 from .monitor import BaseMonitor, MonitorEvent
+from .queue import Queue
 from .transaction import BaseTransaction
-
-
-class QueueEmptyError(Exception):
-    pass
 
 
 class ChannelTimeoutError(AssertionError):
@@ -51,71 +47,6 @@ class DrainPolicy(Enum):
     """Block until only the reference queue is empty"""
     NON_BLOCKING = auto()
     """Do not wait for either queue to drain"""
-
-
-class Queue:
-    """
-    A custom queue implementation that allows peeking onto the head of the queue,
-    which assists with the implementation of funnel-type channels.
-    """
-
-    def __init__(self) -> None:
-        self._entries = []
-        self._on_push = None
-
-    def __len__(self) -> int:
-        return self.level
-
-    def __getitem__(self, key) -> BaseTransaction | list[BaseTransaction]:
-        return self._entries[key]
-
-    @property
-    def level(self) -> int:
-        return len(self._entries)
-
-    @property
-    def on_push_event(self) -> Event:
-        """Expose the event that will be fired on the next push"""
-        if self._on_push is None:
-            self._on_push = Event()
-        return self._on_push
-
-    def push(self, data: Any) -> None:
-        """
-        Push an entry into the queue, notifying any observers that have
-        registered an 'on-push' event.
-
-        :param data: Data to push into the queue
-        """
-        self._entries.append(data)
-        if self._on_push is not None:
-            self._on_push.set()
-        self._on_push = None
-
-    async def pop(self, index: int = 0) -> Any:
-        """
-        Pop an entry from the queue, if necessary blocking until one is available.
-
-        :param index: Index of the item to pop
-        :returns:     Object from the head of the queue
-        """
-        if len(self._entries) == 0:
-            await self.wait()
-        return self._entries.pop(index)
-
-    def wait(self) -> None:
-        """Register an 'on-push' event and wait for it to be set by a push"""
-        return self.on_push_event.wait()
-
-    async def wait_for_not_empty(self) -> None:
-        """Wait until at least one entry exists in the queue"""
-        if self.level == 0:
-            await self.wait()
-
-    def peek(self) -> Any:
-        if len(self._entries) == 0:
-            raise QueueEmptyError()
-        return self._entries[0]
 
 
 class Channel:


### PR DESCRIPTION
Iterables can be mixed with BaseTransaction objects in the queue. 

Driver now uses Forastero Queue rather than cocotb Queue, which has been moved to its own file. 