### PR TITLE
Fix event data being overwritten with None

### DIFF
--- a/forastero/event.py
+++ b/forastero/event.py
@@ -28,8 +28,8 @@ class DataEvent(Event):
         self.data = None
 
     def set(self, data=None):
-        self.data = data
         super().set()
+        self.data = data
 
 
 class EventEmitter:


### PR DESCRIPTION
`EventData.set()` is saving the associated data in a field with the same name as the one in the parent class. Until this field is removed by cocotb upstream, calling `super().set()` after setting `self.data` wipes the field. This patch flips the statements so that this works properly, fixing the return value of `await some_event_emitter.wait_for(event)`, which right now is `None` instead of the event data.