### PR TITLE
Fix cocotb Event.data deprecation in event layer

### DIFF
--- a/forastero/event.py
+++ b/forastero/event.py
@@ -25,11 +25,11 @@ from cocotb.triggers import Event
 class DataEvent(Event):
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
-        self.data = None
+        self._payload = None
 
     def set(self, data=None):
         super().set()
-        self.data = data
+        self._payload = data
 
 
 class EventEmitter:
@@ -93,10 +93,10 @@ class EventEmitter:
             if asyncio.iscoroutine(call):
                 cocotb.start_soon(call)
         # Trigger pending events
-        events = self._waiting[event][:]
+        pending = self._waiting[event][:]
         self._waiting[event].clear()
-        for event in events:
-            event.set(data=obj)
+        for evt in pending:
+            evt.set(data=obj)
 
     def _get_wait_event(self, event: Enum) -> DataEvent:
         evt = DataEvent()
@@ -113,4 +113,4 @@ class EventEmitter:
         """
         evt = self._get_wait_event(event)
         await evt.wait()
-        return evt.data
+        return evt._payload

--- a/forastero/event.py
+++ b/forastero/event.py
@@ -25,11 +25,20 @@ from cocotb.triggers import Event
 class DataEvent(Event):
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
-        self._payload = None
+        self.payload = None
 
     def set(self, data=None):
         super().set()
-        self._payload = data
+        self.payload = data
+
+    @property
+    def data(self):
+        """Alias for the event payload."""
+        return self.payload
+
+    @data.setter
+    def data(self, value):
+        self.payload = value
 
 
 class EventEmitter:
@@ -113,4 +122,4 @@ class EventEmitter:
         """
         evt = self._get_wait_event(event)
         await evt.wait()
-        return evt._payload
+        return evt.payload


### PR DESCRIPTION
cocotb has deprecated and removed the Event.data attribute on its Event trigger. Forastero's event layer (forastero.event) was storing and reading payloads via Event.data in DataEvent and EventEmitter, causing deprecation warnings or runtime failures on newer cocotb.

Changes:
- DataEvent: store payload in _payload instead of .data. Keep the same public API (set(data=None), wait_for() still returns the  payload).
- EventEmitter.publish: fix variable shadowing — the loop variable was named "event", shadowing the Enum parameter. Rename the list to "pending" and the loop variable to "evt" so the parameter remains visible and the code is clearer.
- EventEmitter.wait_for: return evt._payload instead of evt.data.

No change to public behaviour: subscribe, publish, and wait_for behave the same from a consumer's point of view